### PR TITLE
feat: multi-agent blog post + Islamic Golden Age rename + dev workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,0 +1,63 @@
+name: 📋 User Story
+description: Structured user story with acceptance criteria (created by Atlas)
+title: '[Story]: '
+labels: ['feat', 'needs-spec']
+body:
+  - type: markdown
+    attributes:
+      value: '**Structured user story for the engineering team.** Fill in details below.'
+  - type: textarea
+    id: story
+    attributes:
+      label: User Story
+      placeholder: 'As a [user], I want [feature] so that [benefit].'
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      placeholder: |
+        - [ ] Given [context], when [action], then [result]
+        - [ ] Given [context], when [action], then [result]
+    validations:
+      required: true
+  - type: textarea
+    id: technical
+    attributes:
+      label: Technical Notes
+      placeholder: |
+        Components affected:
+        Dependencies:
+        Risk/complexity:
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Estimated Effort
+      options:
+        - S (< 1 hour)
+        - M (1-4 hours)
+        - L (4-8 hours)
+        - XL (> 8 hours)
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 - Critical
+        - P1 - High
+        - P2 - Medium
+        - P3 - Low
+    validations:
+      required: true
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Assigned Agent
+      options:
+        - 🔧 Conan (Engineering)
+        - ✍️ Rewind (Writing)
+        - 📋 Atlas (Planning)
+        - 🤝 Avicenna (General)

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -57,7 +57,7 @@ body:
     attributes:
       label: Assigned Agent
       options:
-        - 🔧 Conan (Engineering)
-        - ✍️ Rewind (Writing)
-        - 📋 Atlas (Planning)
+        - 🔧 Jazari (Engineering)
+        - ✍️ Jahiz (Writing)
+        - 📋 Khawarizmi (Planning)
         - 🤝 Avicenna (General)

--- a/src/content/posts/multi-agent-vps-en.mdx
+++ b/src/content/posts/multi-agent-vps-en.mdx
@@ -1,14 +1,14 @@
 ---
 title: "I Built a Multi-Agent AI System on a $5 VPS — Here's What I Learned"
-publishedAt: "2026-02-25"
-summary: "Four AI agents, one cheap VPS, zero cost. How I set up a multi-agent AI system with OpenClaw — including one that sends daily Quran reflections to my mom."
-image: "/blog/multi-agent-vps/architecture.png"
-tags: ["AI", "OpenClaw", "Multi-Agent", "DevOps"]
-locale: "en"
-canonicalSlug: "multi-agent-vps"
+publishedAt: '2026-02-25'
+summary: 'Five AI agents inspired by Islamic Golden Age scholars, one cheap VPS, zero cost. How I set up a multi-agent AI system with OpenClaw — including one that sends daily Quran reflections to my mom.'
+image: '/blog/multi-agent-vps/architecture.png'
+tags: ['AI', 'OpenClaw', 'Multi-Agent', 'DevOps']
+locale: 'en'
+canonicalSlug: 'multi-agent-vps'
 ---
 
-Last weekend, I set up four AI agents on a single cheap VPS. They talk to me on Telegram, talk to my mom on WhatsApp, write blog posts, build landing pages, and coordinate with each other — all running on free-tier models. It took two days, a lot of YAML editing, and a few spectacular failures. Here's the whole story.
+Last weekend, I set up five AI agents on a single cheap VPS — each named after an Islamic Golden Age scholar. They talk to me on Telegram, talk to my mom on WhatsApp, write blog posts, build landing pages, and coordinate with each other — all running on free-tier models. It took two days, a lot of YAML editing, and a few spectacular failures. Here's the whole story.
 
 ## Why Would Anyone Do This?
 
@@ -18,21 +18,25 @@ When I found [OpenClaw](https://openclaw.ai), an open-source AI assistant framew
 
 Two days later — February 23 and 24, 2026 — I had a working system.
 
-## Meet the Agents
+## Meet the Agents — Islamic Golden Age Scholars 🕌
 
-I created four agents, each with a distinct role and personality:
+I named each agent after an Islamic Golden Age scholar — brilliant minds who shaped mathematics, engineering, medicine, and literature centuries ago. It felt right for a system built on knowledge.
+
+I created five agents, each with a distinct role and personality:
 
 ![Agent Cards](/blog/multi-agent-vps/agent-cards.png)
 
-**Avicenna** 🤝 is my main assistant and coordinator, named after the Persian polymath Ibnu Sina. Casual, helpful, a natural conversationalist. He's connected to both Telegram and WhatsApp, and he's the one I talk to most. Think of him as the team lead.
+**Avicenna** 🤝 is my main coordinator, named after Ibnu Sina — the Persian polymath who wrote _The Canon of Medicine_. Casual, helpful, a natural conversationalist. He's connected to both Telegram and WhatsApp, and he's the one I talk to most. Think of him as the team lead who delegates to specialists.
 
-**Rahma** 🤲 is a spiritual companion built specifically for my mother. She speaks gentle, patient Bahasa Indonesia and sends daily Quran *tadabbur* (reflections) every morning at 5 AM via WhatsApp. This one is personal — my mom isn't technical, but she can open a WhatsApp message.
+**Rahma** 🤲 is a spiritual companion built specifically for my mother. She speaks gentle, patient Bahasa Indonesia and sends daily Quran _tadabbur_ (reflections) every morning at 5 AM via WhatsApp. This one is personal — my mom isn't technical, but she can open a WhatsApp message.
 
-**Rewind** ✍️ is my blog writer and brainstormer. Creative, sharp, adaptive. When I need to think through content ideas or draft a post (like this one), Rewind is who I turn to.
+**Jahiz** ✍️ is my content writer and brainstormer, named after Al-Jahiz — the prolific 9th-century author known for his vivid, observant prose. When I need to think through content ideas or draft a post (like this one), Jahiz is who I turn to.
 
-**Conan** 🔧 is a software engineer and DevOps agent. Resourceful, inventive, loves building things. He handles coding tasks, GitHub integration, and anything that requires getting his hands dirty in a terminal.
+**Jazari** 🔧 is my full-stack engineer, QA specialist, and UI designer all in one — named after Al-Jazari, the legendary 12th-century inventor who created some of the world's first automated machines. He handles coding, testing, GitHub integration, design systems, and anything that requires getting hands dirty in a terminal.
 
-The key insight: each agent has its own `SOUL.md` and `IDENTITY.md` files that define *who they are*, not just what they do. Rahma doesn't just "answer Islamic questions" — she's patient, gentle, and speaks to my mom the way a kind companion would. These personality files matter more than I expected.
+**Khawarizmi** 📋 is my project manager, named after Al-Khawarizmi — the father of algorithms. He breaks down PRDs into structured tickets, plans sprints, tracks progress, and makes sure nothing falls through the cracks. From his name, the word "algorithm" was born — fitting for someone who turns chaos into structured plans.
+
+The key insight: each agent has its own `SOUL.md` and `IDENTITY.md` files that define _who they are_, not just what they do. Rahma doesn't just "answer Islamic questions" — she's patient, gentle, and speaks to my mom the way a kind companion would. These personality files matter more than I expected.
 
 ## The Model Strategy (AKA How I Pay Almost Nothing)
 
@@ -42,8 +46,8 @@ The key: **Google Antigravity OAuth**. With a Google AI Pro subscription, you ge
 
 ```yaml
 models:
-  - google-antigravity/claude-opus-4-6-thinking    # Antigravity (thinking mode)
-  - google-antigravity/claude-opus-4-6              # Antigravity (non-thinking mode)
+  - google-antigravity/claude-opus-4-6-thinking # Antigravity (thinking mode)
+  - google-antigravity/claude-opus-4-6 # Antigravity (non-thinking mode)
 ```
 
 That's it. One Antigravity OAuth account, two model variants. Claude Opus 4.6 in thinking mode handles complex reasoning and multi-step tasks. The non-thinking variant kicks in as a fallback for simpler requests or when the thinking model is rate-limited.
@@ -107,7 +111,7 @@ Small config change, big stability improvement.
 
 Some things I didn't expect at all:
 
-**Agents spawning agents.** I described a landing page I wanted to Avicenna. He decided he wasn't the right agent for the job, spawned Conan as a sub-agent, and Conan built the page. I didn't orchestrate this — Avicenna just... delegated. Watching agents coordinate autonomously was the moment this stopped feeling like a toy and started feeling like a system.
+**Agents spawning agents.** I described a landing page I wanted to Avicenna. He decided he wasn't the right agent for the job, spawned Jazari as a sub-agent, and Jazari built the page. I didn't orchestrate this — Avicenna just... delegated. Watching agents coordinate autonomously was the moment this stopped feeling like a toy and started feeling like a system.
 
 **My mom actually uses it.** Rahma sends a Quran reflection at 5 AM every day. My mom reads it, sometimes responds, and Rahma engages in a gentle conversation about the verse. This isn't a tech demo — it's something my mom genuinely values. That was the most rewarding part of the whole project.
 
@@ -117,13 +121,13 @@ Some things I didn't expect at all:
 
 ## The Landing Page
 
-I even had Conan build a landing page to showcase the agents:
+I even had Jazari build a landing page to showcase the agents:
 
 ![Landing Page](/blog/multi-agent-vps/landing-page.png)
 
 ## Takeaways If You Want to Build This
 
-1. **Start with roles, not models.** Figure out what each agent *is* before you pick which model runs it. The persona design (SOUL.md, IDENTITY.md) matters more than the model selection.
+1. **Start with roles, not models.** Figure out what each agent _is_ before you pick which model runs it. The persona design (SOUL.md, IDENTITY.md) matters more than the model selection.
 
 2. **Use Antigravity OAuth.** A Google AI Pro subscription gives you access to Claude Opus 4.6 — thinking and non-thinking modes. That's enough for a multi-agent personal setup. No separate API keys, no per-token billing.
 

--- a/src/content/posts/multi-agent-vps-en.mdx
+++ b/src/content/posts/multi-agent-vps-en.mdx
@@ -1,14 +1,14 @@
 ---
 title: "I Built a Multi-Agent AI System on a $5 VPS — Here's What I Learned"
 publishedAt: '2026-02-25'
-summary: 'Five AI agents inspired by Islamic Golden Age scholars, one cheap VPS, zero cost. How I set up a multi-agent AI system with OpenClaw — including one that sends daily Quran reflections to my mom.'
+summary: 'Five AI agents inspired by Islamic Golden Age scholars, one cheap VPS. How I set up a multi-agent AI system with OpenClaw — including one that sends daily Quran reflections to my mom.'
 image: '/blog/multi-agent-vps/architecture.png'
 tags: ['AI', 'OpenClaw', 'Multi-Agent', 'DevOps']
 locale: 'en'
 canonicalSlug: 'multi-agent-vps'
 ---
 
-Last weekend, I set up five AI agents on a single cheap VPS — each named after an Islamic Golden Age scholar. They talk to me on Telegram, talk to my mom on WhatsApp, write blog posts, build landing pages, and coordinate with each other — all running on free-tier models. It took two days, a lot of YAML editing, and a few spectacular failures. Here's the whole story.
+Last weekend, I set up five AI agents on a single cheap VPS — each named after an Islamic Golden Age scholar. They talk to me on Telegram, talk to my mom on WhatsApp, write blog posts, build landing pages, and coordinate with each other. It took two days, a lot of YAML editing, and a few spectacular failures. Here's the whole story.
 
 ## Why Would Anyone Do This?
 
@@ -37,22 +37,6 @@ I created five agents, each with a distinct role and personality:
 **Khawarizmi** 📋 is my project manager, named after Al-Khawarizmi — the father of algorithms. He breaks down PRDs into structured tickets, plans sprints, tracks progress, and makes sure nothing falls through the cracks. From his name, the word "algorithm" was born — fitting for someone who turns chaos into structured plans.
 
 The key insight: each agent has its own `SOUL.md` and `IDENTITY.md` files that define _who they are_, not just what they do. Rahma doesn't just "answer Islamic questions" — she's patient, gentle, and speaks to my mom the way a kind companion would. These personality files matter more than I expected.
-
-## The Model Strategy (AKA How I Pay Almost Nothing)
-
-Here's where it gets interesting. Running four agents sounds expensive, but my actual cost? Just a Google AI Pro subscription.
-
-The key: **Google Antigravity OAuth**. With a Google AI Pro subscription, you get access to powerful models through your Google account — no separate API keys, no per-token billing, no usage limits that matter for personal use.
-
-```yaml
-models:
-  - google-antigravity/claude-opus-4-6-thinking # Antigravity (thinking mode)
-  - google-antigravity/claude-opus-4-6 # Antigravity (non-thinking mode)
-```
-
-That's it. One Antigravity OAuth account, two model variants. Claude Opus 4.6 in thinking mode handles complex reasoning and multi-step tasks. The non-thinking variant kicks in as a fallback for simpler requests or when the thinking model is rate-limited.
-
-In practice, this handles 100% of my requests. Four agents, running 24/7, all through one subscription. No per-token costs, no surprise bills.
 
 ## Multi-Channel Routing
 
@@ -93,7 +77,7 @@ I learned this one the hard way. When an agent tries to restart the OpenClaw gat
 
 ### 4. Forward-Compatible Models Aren't
 
-I noticed `gemini-3.1` listed in the Antigravity codebase and got excited. It returns a 404. The model identifiers are there for forward compatibility, but the models themselves don't exist yet. Don't chase model names in source code.
+I noticed newer model identifiers in the codebase and got excited. They return 404. The identifiers are there for forward compatibility, but the models themselves don't exist yet. Don't chase model names in source code.
 
 ### 5. Context Windows Overflow Silently
 
@@ -115,8 +99,6 @@ Some things I didn't expect at all:
 
 **My mom actually uses it.** Rahma sends a Quran reflection at 5 AM every day. My mom reads it, sometimes responds, and Rahma engages in a gentle conversation about the verse. This isn't a tech demo — it's something my mom genuinely values. That was the most rewarding part of the whole project.
 
-**Free models are enough.** I was prepared to spend a lot. I didn't have to. Claude Opus 4.6 via Antigravity OAuth handles complex reasoning, multi-step tasks, and nuanced conversation without breaking a sweat. For a personal multi-agent setup, you don't need a $200/month API bill — you need one Google AI Pro subscription.
-
 **Personality files are the secret sauce.** The difference between a generic assistant and Rahma — who speaks with warmth and patience to my mother — isn't the model. It's the `SOUL.md` file. Investing time in writing detailed personality definitions pays off in every single interaction.
 
 ## The Landing Page
@@ -129,12 +111,10 @@ I even had Jazari build a landing page to showcase the agents:
 
 1. **Start with roles, not models.** Figure out what each agent _is_ before you pick which model runs it. The persona design (SOUL.md, IDENTITY.md) matters more than the model selection.
 
-2. **Use Antigravity OAuth.** A Google AI Pro subscription gives you access to Claude Opus 4.6 — thinking and non-thinking modes. That's enough for a multi-agent personal setup. No separate API keys, no per-token billing.
+2. **Design for your least technical user.** My mom can't send slash commands and doesn't know what "context compaction" means. If you want real people to use your agents, automate the maintenance (cron jobs, auto-compaction) and keep the interface invisible.
 
-3. **Design for your least technical user.** My mom can't send slash commands and doesn't know what "context compaction" means. If you want real people to use your agents, automate the maintenance (cron jobs, auto-compaction) and keep the interface invisible.
+3. **Expect the weird edge cases.** Agents killing their own gateway. Announce delivery modes that need raw text, not tool calls. These aren't in the docs — you find them at 2 AM when things break.
 
-4. **Expect the weird edge cases.** Agents killing their own gateway. Announce delivery modes that need raw text, not tool calls. These aren't in the docs — you find them at 2 AM when things break.
+4. **A $5 VPS is genuinely enough.** The agents are stateless between requests — the heavy lifting happens on the model provider's side. Your VPS just runs the gateway and routes messages. You don't need GPU, you don't need 32GB RAM. You need a Linux box and an internet connection.
 
-5. **A $5 VPS is genuinely enough.** The agents are stateless between requests — the heavy lifting happens on the model provider's side. Your VPS just runs the gateway and routes messages. You don't need GPU, you don't need 32GB RAM. You need a Linux box and an internet connection.
-
-The whole thing took two days. The tools are open source. The models are free. The hardest part was writing good personality files and debugging cron job timing. If that sounds like a weekend project you'd enjoy — it is.
+The whole thing took two days. The tools are open source. The hardest part was writing good personality files and debugging cron job timing. If that sounds like a weekend project you'd enjoy — it is.

--- a/src/content/posts/multi-agent-vps-id.mdx
+++ b/src/content/posts/multi-agent-vps-id.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Membangun Sistem Multi-Agent AI di VPS Murah — Ini yang Saya Pelajari"
-publishedAt: "2026-02-25"
-summary: "Empat AI agent, satu VPS, nol biaya model. Cara saya setup sistem multi-agent AI dengan OpenClaw — termasuk satu yang kirim tadabbur harian ke ibu saya."
-image: "/blog/multi-agent-vps/architecture.png"
-tags: ["AI", "OpenClaw", "Multi-Agent", "DevOps"]
-locale: "id"
-canonicalSlug: "multi-agent-vps"
+title: 'Membangun Sistem Multi-Agent AI di VPS Murah — Ini yang Saya Pelajari'
+publishedAt: '2026-02-25'
+summary: 'Lima AI agent terinspirasi sarjana Islamic Golden Age, satu VPS, nol biaya model. Cara saya setup sistem multi-agent AI dengan OpenClaw — termasuk satu yang kirim tadabbur harian ke ibu saya.'
+image: '/blog/multi-agent-vps/architecture.png'
+tags: ['AI', 'OpenClaw', 'Multi-Agent', 'DevOps']
+locale: 'id'
+canonicalSlug: 'multi-agent-vps'
 ---
 
-Dua hari. Satu VPS. Empat AI agent dengan kepribadian berbeda. Nol biaya model.
+Dua hari. Satu VPS. Lima AI agent dengan kepribadian berbeda — masing-masing dinamai sarjana dari Islamic Golden Age. Nol biaya model.
 
 Kedengarannya kayak clickbait? Saya juga bakal skeptis kalau baca judul itu. Tapi ini beneran kejadian — 23-24 Februari 2026, saya duduk di depan terminal dan membangun sistem multi-agent AI yang sekarang jalan 24/7 di sebuah VPS Linux. Salah satu agent-nya bahkan kirim refleksi Al-Quran ke ibu saya setiap jam 5 pagi.
 
@@ -16,15 +16,17 @@ Mari saya ceritakan gimana prosesnya — termasuk semua kesalahan bodoh yang say
 
 ## Kenapa Multi-Agent?
 
-Saya sudah lama pakai AI assistant untuk berbagai keperluan. Tapi satu agent untuk semua kebutuhan itu kayak punya satu pisau Swiss Army untuk masak, berkebun, dan operasi jantung sekaligus. *Technically* bisa, tapi hasilnya... ya begitulah.
+Saya sudah lama pakai AI assistant untuk berbagai keperluan. Tapi satu agent untuk semua kebutuhan itu kayak punya satu pisau Swiss Army untuk masak, berkebun, dan operasi jantung sekaligus. _Technically_ bisa, tapi hasilnya... ya begitulah.
 
 Yang saya butuhkan:
+
 - Asisten pribadi yang bisa diajak ngobrol natural via Telegram dan WhatsApp
 - Teman spiritual untuk ibu saya yang nyaman pakai WhatsApp
 - Penulis konten yang paham style saya
-- Engineer yang bisa ngoding dan handle DevOps
+- Engineer yang bisa ngoding, testing, dan handle UI
+- Project manager yang bisa breakdown requirement jadi tiket
 
-Empat peran. Empat kepribadian. Satu framework.
+Lima peran. Lima kepribadian. Satu framework.
 
 ## Framework: OpenClaw
 
@@ -32,15 +34,17 @@ Saya pakai [OpenClaw](https://openclaw.ai) — framework AI assistant open-sourc
 
 Setup-nya straightforward. Install di VPS, konfigurasi gateway, definisikan agent — dan mereka hidup.
 
-## Empat Agent, Empat Kepribadian
+## Lima Agent, Lima Sarjana — Islamic Golden Age 🕌
+
+Saya menamakan setiap agent berdasarkan sarjana dari Islamic Golden Age — para jenius yang membentuk matematika, engineering, kedokteran, dan sastra berabad-abad lalu.
 
 ![Agent Cards](/blog/multi-agent-vps/agent-cards.png)
 
 ### 1. Avicenna 🤝 — Si Koordinator
 
-Terinspirasi dari Ibnu Sina. Avicenna adalah asisten utama saya — santai, helpful, dan ngobrol natural. Dia terhubung ke Telegram dan WhatsApp, jadi saya bisa chat dari mana aja.
+Terinspirasi dari Ibnu Sina, sang polymath yang menulis _The Canon of Medicine_. Avicenna adalah asisten utama saya — santai, helpful, dan ngobrol natural. Dia terhubung ke Telegram dan WhatsApp, jadi saya bisa chat dari mana aja.
 
-Tapi yang bikin Avicenna spesial bukan cuma dia bisa jawab pertanyaan. Dia bisa *mendelegasikan*. Butuh landing page? Avicenna spawn Conan (agent engineer) sebagai sub-agent untuk mengerjakannya. Saya cukup bilang ke Avicenna apa yang saya mau, dan dia orkestrasi sisanya.
+Tapi yang bikin Avicenna spesial bukan cuma dia bisa jawab pertanyaan. Dia bisa _mendelegasikan_. Butuh landing page? Avicenna spawn Jazari (agent engineer) sebagai sub-agent untuk mengerjakannya. Saya cukup bilang ke Avicenna apa yang saya mau, dan dia orkestrasi sisanya.
 
 ### 2. Rahma 🤲 — Teman Spiritual Ibu
 
@@ -48,23 +52,27 @@ Ini agent yang paling personal. Ibu saya sudah sepuh dan suka baca tadabbur Al-Q
 
 Setiap jam 5 pagi, Rahma mengirim refleksi Al-Quran harian ke WhatsApp ibu saya. Otomatis. Konsisten. Tanpa saya harus ingat-ingat.
 
-Channel binding-nya saya set supaya setiap pesan WhatsApp dari nomor ibu saya *selalu* diarahkan ke Rahma — bukan ke Avicenna atau agent lain. Plus, WhatsApp pakai kebijakan allowlist untuk keamanan, jadi nggak sembarang nomor bisa interact.
+Channel binding-nya saya set supaya setiap pesan WhatsApp dari nomor ibu saya _selalu_ diarahkan ke Rahma — bukan ke Avicenna atau agent lain. Plus, WhatsApp pakai kebijakan allowlist untuk keamanan, jadi nggak sembarang nomor bisa interact.
 
-### 3. Rewind ✍️ — Si Penulis
+### 3. Jahiz ✍️ — Si Penulis
 
-Rewind itu penulis blog dan brainstormer. Kreatif, tajam, adaptif. Kalau saya butuh draft artikel (termasuk artikel yang sedang Anda baca ini), Rewind yang handle.
+Terinspirasi dari Al-Jahiz, sastrawan dan penulis prolifik abad ke-9 yang dikenal karena gaya tulisnya yang hidup dan penuh observasi. Jahiz itu penulis blog dan brainstormer saya. Kreatif, tajam, adaptif. Kalau saya butuh draft artikel (termasuk artikel yang sedang Anda baca ini), Jahiz yang handle.
 
-### 4. Conan 🔧 — Si Engineer
+### 4. Jazari 🔧 — Si Engineer
 
-Software engineer dan DevOps dalam satu paket. Resourceful, inventif, dan suka ngoding. Conan handle tugas coding, integrasi GitHub, dan build apa pun yang perlu di-build.
+Terinspirasi dari Al-Jazari, insinyur dan inventor legendaris abad ke-12 yang menciptakan mesin-mesin otomatis pertama di dunia. Jazari adalah full-stack engineer, QA specialist, dan UI designer dalam satu paket. Dia handle coding, testing, GitHub integration, design system, dan build apa pun yang perlu di-build.
 
-Momen favorit saya: saya deskripsikan landing page yang saya mau ke Avicenna, Avicenna spawn Conan sebagai sub-agent, dan Conan membangun halaman itu secara lengkap. Saya tinggal review hasilnya.
+Momen favorit saya: saya deskripsikan landing page yang saya mau ke Avicenna, Avicenna spawn Jazari sebagai sub-agent, dan Jazari membangun halaman itu secara lengkap. Saya tinggal review hasilnya.
+
+### 5. Khawarizmi 📋 — Si Project Manager
+
+Terinspirasi dari Al-Khawarizmi, bapak algoritma dan aljabar — dari namanya lahir kata "algorithm." Khawarizmi breakdown PRD jadi user stories terstruktur, bikin GitHub Issues dengan label dan prioritas, planning sprint, dan track progress. Dia yang bikin chaos jadi terorganisir.
 
 ## Kepribadian Itu Bukan Gimmick
 
 Ini pelajaran penting yang mau saya tekankan: **kepribadian agent itu bukan sekadar flavor text.**
 
-Di OpenClaw, setiap agent punya file `SOUL.md` dan `IDENTITY.md` yang mendefinisikan *siapa* mereka — bukan cuma *apa* yang mereka lakukan. Rahma nggak cuma "agent yang kirim ayat Quran." Rahma adalah teman yang sabar, lembut, dan tahu kapan harus mendengarkan.
+Di OpenClaw, setiap agent punya file `SOUL.md` dan `IDENTITY.md` yang mendefinisikan _siapa_ mereka — bukan cuma _apa_ yang mereka lakukan. Rahma nggak cuma "agent yang kirim ayat Quran." Rahma adalah teman yang sabar, lembut, dan tahu kapan harus mendengarkan.
 
 Perbedaan ini kelihatan banget di output. Agent dengan kepribadian yang well-defined menghasilkan respons yang jauh lebih konsisten dan natural dibanding agent yang cuma dikasih daftar instruksi.
 
@@ -77,8 +85,8 @@ Rahasianya: **Google Antigravity OAuth**. Dengan berlangganan Google AI Pro, And
 ```yaml
 # Model yang dipakai (per agent)
 models:
-  - google-antigravity/claude-opus-4-6-thinking    # Antigravity (thinking mode)
-  - google-antigravity/claude-opus-4-6              # Antigravity (non-thinking mode)
+  - google-antigravity/claude-opus-4-6-thinking # Antigravity (thinking mode)
+  - google-antigravity/claude-opus-4-6 # Antigravity (non-thinking mode)
 ```
 
 Sesimpel itu. Satu akun Antigravity OAuth, dua varian model. Claude Opus 4.6 dalam thinking mode untuk reasoning kompleks dan tugas multi-step. Varian non-thinking sebagai fallback untuk request yang lebih simpel atau ketika model thinking kena rate limit.
@@ -90,6 +98,7 @@ Dalam praktiknya, ini handle 100% request saya. Empat agent, berjalan 24/7, semu
 ![Channel Routing](/blog/multi-agent-vps/channel-routing.png)
 
 Setup messaging-nya simpel tapi powerful. Saya punya:
+
 - **Bot Telegram** untuk personal use
 - **Bot WhatsApp** yang dipakai saya dan ibu saya
 
@@ -111,15 +120,15 @@ Solusi: cron job auto-compaction setiap 2 jam. Simple, tapi krusial. Tanpa ini, 
 
 Rahma perlu kirim tadabbur jam 5 pagi. Saya pakai cron job dengan delivery mode `announce` — artinya output agent langsung dikirim sebagai pesan ke user.
 
-Yang saya pelajari dengan cara yang menyakitkan: kalau agent merespons dengan memanggil tools (bukan menulis teks langsung), announce *nggak punya apa-apa untuk dikirim*. Hening. Nggak ada pesan.
+Yang saya pelajari dengan cara yang menyakitkan: kalau agent merespons dengan memanggil tools (bukan menulis teks langsung), announce _nggak punya apa-apa untuk dikirim_. Hening. Nggak ada pesan.
 
 Solusinya: instruksikan agent secara eksplisit dalam cron prompt untuk **menulis teks langsung**, bukan memanggil tools.
 
 ### 3. Jangan Restart Gateway dari Dalam Agent
 
-Ini kesalahan klasik yang saya buat lebih dari sekali. Agent butuh restart gateway → agent jalankan perintah restart → gateway mati → agent ikut mati karena dia *berjalan di atas gateway yang sama*.
+Ini kesalahan klasik yang saya buat lebih dari sekali. Agent butuh restart gateway → agent jalankan perintah restart → gateway mati → agent ikut mati karena dia _berjalan di atas gateway yang sama_.
 
-Kayak duduk di dahan pohon yang sedang Anda gergaji sendiri. Masalah timing yang obvious *setelah* kejadian, tapi nggak kepikiran *sebelum* kejadian.
+Kayak duduk di dahan pohon yang sedang Anda gergaji sendiri. Masalah timing yang obvious _setelah_ kejadian, tapi nggak kepikiran _sebelum_ kejadian.
 
 ### 4. Model yang Belum Ada
 
@@ -141,15 +150,15 @@ Angka 6000 cukup untuk memberikan ruang napas sebelum context window benar-benar
 
 Beberapa momen "wow" yang nggak saya antisipasi:
 
-**Agent men-spawn agent lain.** Ketika saya minta Avicenna buatkan landing page, dia nggak mencoba mengerjakannya sendiri. Dia spawn Conan sebagai sub-agent, delegasikan tugas, dan report hasilnya ke saya. Ini bukan sesuatu yang saya program secara eksplisit — ini perilaku yang muncul dari arsitektur multi-agent OpenClaw.
+**Agent men-spawn agent lain.** Ketika saya minta Avicenna buatkan landing page, dia nggak mencoba mengerjakannya sendiri. Dia spawn Jazari sebagai sub-agent, delegasikan tugas, dan report hasilnya ke saya. Ini bukan sesuatu yang saya program secara eksplisit — ini perilaku yang muncul dari arsitektur multi-agent OpenClaw.
 
 **Konsistensi Rahma.** Setiap pagi jam 5, ibu saya dapat pesan refleksi Quran. Bukan copy-paste yang sama setiap hari. Setiap pesan unik, thoughtful, dan ditulis dengan bahasa yang lembut. Ibu saya senang. Itu... itu worth more than any technical achievement di project ini.
 
-**Biaya minimal.** Empat agent berjalan 24/7, dan saya cuma perlu satu langganan Google AI Pro — tanpa biaya per-token tambahan.
+**Biaya minimal.** Lima agent berjalan 24/7, dan saya cuma perlu satu langganan Google AI Pro — tanpa biaya per-token tambahan.
 
 ## Landing Page
 
-Saya bahkan minta Conan buatkan landing page untuk showcase semua agent:
+Saya bahkan minta Jazari buatkan landing page untuk showcase semua agent:
 
 ![Landing Page](/blog/multi-agent-vps/landing-page.png)
 
@@ -169,6 +178,6 @@ Beberapa pelajaran actionable dari 2 hari eksperimen ini:
 
 ---
 
-Dua hari. Empat agent. Satu langganan AI Pro. Satu ibu yang senang dapat kiriman tadabbur setiap pagi.
+Dua hari. Lima agent. Satu langganan AI Pro. Satu ibu yang senang dapat kiriman tadabbur setiap pagi.
 
 Kalau itu bukan ROI yang bagus, saya nggak tahu apa lagi.

--- a/src/content/posts/multi-agent-vps-id.mdx
+++ b/src/content/posts/multi-agent-vps-id.mdx
@@ -1,14 +1,14 @@
 ---
 title: 'Membangun Sistem Multi-Agent AI di VPS Murah — Ini yang Saya Pelajari'
 publishedAt: '2026-02-25'
-summary: 'Lima AI agent terinspirasi sarjana Islamic Golden Age, satu VPS, nol biaya model. Cara saya setup sistem multi-agent AI dengan OpenClaw — termasuk satu yang kirim tadabbur harian ke ibu saya.'
+summary: 'Lima AI agent terinspirasi sarjana Islamic Golden Age, satu VPS murah. Cara saya setup sistem multi-agent AI dengan OpenClaw — termasuk satu yang kirim tadabbur harian ke ibu saya.'
 image: '/blog/multi-agent-vps/architecture.png'
 tags: ['AI', 'OpenClaw', 'Multi-Agent', 'DevOps']
 locale: 'id'
 canonicalSlug: 'multi-agent-vps'
 ---
 
-Dua hari. Satu VPS. Lima AI agent dengan kepribadian berbeda — masing-masing dinamai sarjana dari Islamic Golden Age. Nol biaya model.
+Dua hari. Satu VPS. Lima AI agent dengan kepribadian berbeda — masing-masing dinamai sarjana dari Islamic Golden Age.
 
 Kedengarannya kayak clickbait? Saya juga bakal skeptis kalau baca judul itu. Tapi ini beneran kejadian — 23-24 Februari 2026, saya duduk di depan terminal dan membangun sistem multi-agent AI yang sekarang jalan 24/7 di sebuah VPS Linux. Salah satu agent-nya bahkan kirim refleksi Al-Quran ke ibu saya setiap jam 5 pagi.
 
@@ -76,23 +76,6 @@ Di OpenClaw, setiap agent punya file `SOUL.md` dan `IDENTITY.md` yang mendefinis
 
 Perbedaan ini kelihatan banget di output. Agent dengan kepribadian yang well-defined menghasilkan respons yang jauh lebih konsisten dan natural dibanding agent yang cuma dikasih daftar instruksi.
 
-## Strategi Model: Biaya Minimal untuk AI
-
-Ini bagian yang paling bikin saya excited. Seluruh sistem lima agent ini berjalan dengan biaya minimal — cukup langganan Google AI Pro.
-
-Rahasianya: **Google Antigravity OAuth**. Dengan berlangganan Google AI Pro, Anda dapat akses ke model-model powerful melalui akun Google — tanpa API key terpisah, tanpa biaya per-token, tanpa limit yang berarti untuk pemakaian personal.
-
-```yaml
-# Model yang dipakai (per agent)
-models:
-  - google-antigravity/claude-opus-4-6-thinking # Antigravity (thinking mode)
-  - google-antigravity/claude-opus-4-6 # Antigravity (non-thinking mode)
-```
-
-Sesimpel itu. Satu akun Antigravity OAuth, dua varian model. Claude Opus 4.6 dalam thinking mode untuk reasoning kompleks dan tugas multi-step. Varian non-thinking sebagai fallback untuk request yang lebih simpel atau ketika model thinking kena rate limit.
-
-Dalam praktiknya, ini handle 100% request saya. Lima agent, berjalan 24/7, semuanya lewat satu langganan. Tanpa biaya per-token, tanpa tagihan mengejutkan.
-
 ## Multi-Channel Routing
 
 ![Channel Routing](/blog/multi-agent-vps/channel-routing.png)
@@ -132,7 +115,7 @@ Kayak duduk di dahan pohon yang sedang Anda gergaji sendiri. Masalah timing yang
 
 ### 4. Model yang Belum Ada
 
-Di kode Antigravity, saya lihat ada opsi Gemini 3.1. "Oh keren, model baru!" Ternyata return 404. Model itu forward-compatible entry yang belum tersedia. Pelajaran: jangan asumsikan semua opsi di kode itu ready.
+Di kode framework, saya lihat ada identifier model baru. "Oh keren!" Ternyata return 404. Identifier itu forward-compatible entry yang belum tersedia. Pelajaran: jangan asumsikan semua opsi di kode itu ready.
 
 ### 5. Context Overflow
 
@@ -154,8 +137,6 @@ Beberapa momen "wow" yang nggak saya antisipasi:
 
 **Konsistensi Rahma.** Setiap pagi jam 5, ibu saya dapat pesan refleksi Quran. Bukan copy-paste yang sama setiap hari. Setiap pesan unik, thoughtful, dan ditulis dengan bahasa yang lembut. Ibu saya senang. Itu... itu worth more than any technical achievement di project ini.
 
-**Biaya minimal.** Lima agent berjalan 24/7, dan saya cuma perlu satu langganan Google AI Pro — tanpa biaya per-token tambahan.
-
 ## Landing Page
 
 Saya bahkan minta Jazari buatkan landing page untuk showcase semua agent:
@@ -168,16 +149,14 @@ Beberapa pelajaran actionable dari 2 hari eksperimen ini:
 
 1. **Mulai dari "siapa", bukan "apa."** Definisikan kepribadian agent sebelum definisikan tugasnya. File `SOUL.md` lebih penting dari daftar tools.
 
-2. **Pakai Antigravity OAuth.** Langganan Google AI Pro memberikan akses ke Claude Opus 4.6 — mode thinking dan non-thinking. Cukup untuk setup multi-agent personal. Tanpa API key terpisah, tanpa biaya per-token.
+2. **Pikirkan user experience non-teknis.** Kalau agent Anda akan dipakai orang yang nggak tech-savvy (seperti ibu saya), semua harus otomatis. Nggak ada slash command. Nggak ada manual compaction. Nggak ada "coba restart."
 
-3. **Pikirkan user experience non-teknis.** Kalau agent Anda akan dipakai orang yang nggak tech-savvy (seperti ibu saya), semua harus otomatis. Nggak ada slash command. Nggak ada manual compaction. Nggak ada "coba restart."
+3. **Test edge case yang aneh.** Restart server dari dalam agent. Announce delivery yang butuh raw text. Ini nggak ada di dokumentasi — Anda temukannya jam 2 pagi ketika semuanya rusak.
 
-4. **Test edge case yang aneh.** Restart server dari dalam agent. Announce delivery yang butuh raw text. Ini nggak ada di dokumentasi — Anda temukannya jam 2 pagi ketika semuanya rusak.
-
-5. **VPS murah itu cukup.** Anda nggak butuh GPU, nggak butuh server mahal. Framework-nya jalan di VPS, model-nya di cloud. Yang Anda bayar cuma VPS-nya — dan bahkan itu murah.
+4. **VPS murah itu cukup.** Anda nggak butuh GPU, nggak butuh server mahal. Framework-nya jalan di VPS, model-nya di cloud. Yang Anda bayar cuma VPS-nya — dan bahkan itu murah.
 
 ---
 
-Dua hari. Lima agent. Satu langganan AI Pro. Satu ibu yang senang dapat kiriman tadabbur setiap pagi.
+Dua hari. Lima agent. Satu ibu yang senang dapat kiriman tadabbur setiap pagi.
 
 Kalau itu bukan ROI yang bagus, saya nggak tahu apa lagi.

--- a/src/content/posts/multi-agent-vps-id.mdx
+++ b/src/content/posts/multi-agent-vps-id.mdx
@@ -78,7 +78,7 @@ Perbedaan ini kelihatan banget di output. Agent dengan kepribadian yang well-def
 
 ## Strategi Model: Biaya Minimal untuk AI
 
-Ini bagian yang paling bikin saya excited. Seluruh sistem empat agent ini berjalan dengan biaya minimal — cukup langganan Google AI Pro.
+Ini bagian yang paling bikin saya excited. Seluruh sistem lima agent ini berjalan dengan biaya minimal — cukup langganan Google AI Pro.
 
 Rahasianya: **Google Antigravity OAuth**. Dengan berlangganan Google AI Pro, Anda dapat akses ke model-model powerful melalui akun Google — tanpa API key terpisah, tanpa biaya per-token, tanpa limit yang berarti untuk pemakaian personal.
 
@@ -91,7 +91,7 @@ models:
 
 Sesimpel itu. Satu akun Antigravity OAuth, dua varian model. Claude Opus 4.6 dalam thinking mode untuk reasoning kompleks dan tugas multi-step. Varian non-thinking sebagai fallback untuk request yang lebih simpel atau ketika model thinking kena rate limit.
 
-Dalam praktiknya, ini handle 100% request saya. Empat agent, berjalan 24/7, semuanya lewat satu langganan. Tanpa biaya per-token, tanpa tagihan mengejutkan.
+Dalam praktiknya, ini handle 100% request saya. Lima agent, berjalan 24/7, semuanya lewat satu langganan. Tanpa biaya per-token, tanpa tagihan mengejutkan.
 
 ## Multi-Channel Routing
 
@@ -102,7 +102,7 @@ Setup messaging-nya simpel tapi powerful. Saya punya:
 - **Bot Telegram** untuk personal use
 - **Bot WhatsApp** yang dipakai saya dan ibu saya
 
-Setiap pesan WhatsApp dari nomor ibu saya otomatis diarahkan ke Rahma. Tanpa command, tanpa menu, tanpa bingung. Ibu buka WhatsApp, kirim pesan, Rahma jawab dengan bahasa Indonesia yang lembut. Ibu nggak tahu dan nggak perlu tahu ada empat agent — dia cuma ngobrol sama "asisten-nya."
+Setiap pesan WhatsApp dari nomor ibu saya otomatis diarahkan ke Rahma. Tanpa command, tanpa menu, tanpa bingung. Ibu buka WhatsApp, kirim pesan, Rahma jawab dengan bahasa Indonesia yang lembut. Ibu nggak tahu dan nggak perlu tahu ada lima agent — dia cuma ngobrol sama "asisten-nya."
 
 ## Arsitektur Sistem
 


### PR DESCRIPTION
## 📝 Summary

Bilingual blog post about the multi-agent AI setup, plus development workflow improvements.

### Blog Posts
- `multi-agent-vps-en.mdx` — English version
- `multi-agent-vps-id.mdx` — Indonesian version
- Language switcher via `locale` + `canonicalSlug` frontmatter
- 4 custom images in `public/blog/multi-agent-vps/`
- **Agents renamed** to Islamic Golden Age scholars (Jazari, Jahiz, Khawarizmi)
- **Model strategy section removed** — focus on agents, not pricing

### Dev Workflow
- ✅ Vitest — 30 tests (blog validation + MDX utils)
- ✅ GitHub Actions CI (lint + typecheck + test + build)
- ✅ Prettier + Husky + lint-staged
- ✅ PR/Issue templates (bug report, feature request, user story)

### Security
- ✅ Fixed CVE-2026-0969: next-mdx-remote 5.0.0 → 6.0.0

### Closes
- Closes #6 (rename agents to Islamic Golden Age scholars)

---
*By the crew: Avicenna 🤝 Jazari 🔧 Jahiz ✍️*